### PR TITLE
Correct query parameters validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,23 +64,23 @@ module.exports = {
             route.validators.forEach(function (validator) {
                 config.validate = {};
 
-                switch (validator.parameter.in) {
-                    case 'header':
-                        config.validate.headers = config.validate.headers || {};
-                        config.validate.headers[validator.parameter.name] = validator.schema;
-                        break;
-                    case 'path':
-                        config.validate.params = config.validate.params || {};
-                        config.validate.params[validator.parameter.name] = validator.schema;
-                        break;
-                    case 'query':
-                        config.validate.query = config.validate.query || {};
-                        config.validate.query[validator.parameter.name] = validator.schema;
-                        break;
-                    case 'body':
-                    case 'form':
-                        config.validate.payload = validator.schema;
-                        break;
+                if (validator.parameter.in == 'body' || validator.parameter.in == 'form') {
+                    return config.validate.payload = validator.schema;
+                }
+
+                var swaggerToHapiParameterMapping = {
+                    header: 'headers',
+                    path: 'params',
+                    query: 'query'
+                }
+
+                for (var swaggerType in swaggerToHapiParameterMapping) {
+                    if (validator.parameter.in == swaggerType) {
+                        var hapiType = swaggerToHapiParameterMapping[swaggerType];
+
+                        config.validate[hapiType] = config.validate[hapiType] || {};
+                        config.validate[hapiType][validator.parameter.name] = validator.schema;
+                    }
                 }
             });
 


### PR DESCRIPTION
As specified in [Hapi](http://hapijs.com/api#route-options), `params` is used for path parameters, and `query` for query parameters.
