### PR TITLE
Skip empty descriptions for routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ launch.json
 .iml
 *.sublime-workspace
 *.sublime-project
+.vscode
 
 .DS_Store*
 ehthumbs.db

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -47,9 +47,8 @@ const create = async function (server, { api, basedir, cors, vhost, handlers, ex
             const options = Object.assign({
                 cors,
                 id: operation.operationId,
-                description: operation.description !== '' ? operation.description : undefined, // hapi does not
-                                                                                               // support empty
-                                                                                               // descriptions
+                // hapi does not support empty descriptions
+                description: operation.description !== '' ? operation.description : undefined,
                 tags: ['api']
             }, xoptions);
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -11,7 +11,7 @@ const Props = require('dot-prop');
 const create = async function (server, { api, basedir, cors, vhost, handlers, extensions, outputvalidation }) {
     const routes = [];
     const validator = Validators.create({ api });
-    
+
     if (typeof handlers === 'string') {
         handlers = await ObjectFiles.merge(handlers, extensions);
     }
@@ -47,7 +47,7 @@ const create = async function (server, { api, basedir, cors, vhost, handlers, ex
             const options = Object.assign({
                 cors,
                 id: operation.operationId,
-                description: operation.description,
+                description: operation.description !== '' ? operation.description : null,
                 tags: ['api']
             }, xoptions);
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -47,7 +47,9 @@ const create = async function (server, { api, basedir, cors, vhost, handlers, ex
             const options = Object.assign({
                 cors,
                 id: operation.operationId,
-                description: operation.description !== '' ? operation.description : undefined,
+                description: operation.description !== '' ? operation.description : undefined, // hapi does not
+                                                                                               // support empty
+                                                                                               // descriptions
                 tags: ['api']
             }, xoptions);
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -47,7 +47,7 @@ const create = async function (server, { api, basedir, cors, vhost, handlers, ex
             const options = Object.assign({
                 cors,
                 id: operation.operationId,
-                description: operation.description !== '' ? operation.description : null,
+                description: operation.description !== '' ? operation.description : undefined,
                 tags: ['api']
             }, xoptions);
 

--- a/test/test-hapi-openapi.js
+++ b/test/test-hapi-openapi.js
@@ -64,7 +64,7 @@ Test('test plugin', function (t) {
                 }
             }
         };
-        
+
         try {
             await server.register({
                 plugin: OpenAPI,
@@ -199,7 +199,7 @@ Test('test plugin', function (t) {
                 }
             }
         };
-        
+
         try {
             await server.register({
                 plugin: OpenAPI,
@@ -252,7 +252,7 @@ Test('test plugin', function (t) {
                 }
             }
         };
-        
+
         try {
             await server.register({
                 plugin: OpenAPI,
@@ -530,6 +530,53 @@ Test('test plugin', function (t) {
             }
 
             t.end();
+        }
+        catch (error) {
+            t.fail(error.message);
+        }
+    });
+
+    t.test('skip empty path descriptions', async function (t) {
+        t.plan(1);
+
+        const server = new Hapi.Server();
+
+        const api = {
+            swagger: '2.0',
+            info: {
+                title: 'Minimal',
+                version: '1.0.0'
+            },
+            paths: {
+                '/test': {
+                    get: {
+                        description: '',
+                        responses: {
+                            200: {
+                                description: 'default response'
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        try {
+            await server.register({
+                plugin: OpenAPI,
+                options: {
+                    api,
+                    handlers: {
+                        test: {
+                            get(request, h) {
+                                return 'test';
+                            }
+                        }
+                    }
+                }
+            });
+
+            t.pass();
         }
         catch (error) {
             t.fail(error.message);


### PR DESCRIPTION
Fix #117 

## Summary

Since hapi doesn't support empty descriptions (but OpenAPI does), this PR skips those empty descriptions from the OpenAPI definition when it is building the routes.

## Other information

I've added a couple of specs for this case as well as ignored the `vscode` folder.