### PR TITLE
Allow payload options to be customized

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -54,10 +54,17 @@ const create = async function (server, { api, basedir, cors, vhost, handlers, ex
             options.handler = handler;
 
             if (Utils.canCarry(method)) {
-                options.payload = {
-                    allow: operation.consumes || api.consumes
-                };
+                if (options.payload) {
+                    if (!options.payload.allow) {
+                        options.payload.allow = operation.consumes || api.consumes;
+                    }
+                } else {
+                    options.payload = {
+                        allow: operation.consumes || api.consumes
+                    };
+                }
             }
+            const skipValidation = options.payload && options.payload.parse === false;
 
             if (Array.isArray(handler)) {
                 options.pre = [];
@@ -71,7 +78,7 @@ const create = async function (server, { api, basedir, cors, vhost, handlers, ex
                 options.handler = handler[handler.length - 1];
             }
 
-            if (operation.parameters) {
+            if (operation.parameters && !skipValidation) {
                 const v = validator.makeAll(operation.parameters, operation.consumes || api.consumes);
                 options.validate = v.validate;
                 options.ext = {
@@ -79,7 +86,7 @@ const create = async function (server, { api, basedir, cors, vhost, handlers, ex
                 };
             }
 
-            if (outputvalidation && operation.responses) {
+            if (outputvalidation && operation.responses && !skipValidation) {
                 options.response = {};
                 options.response.status = validator.makeResponseValidator(operation.responses);
             }


### PR DESCRIPTION
Currently, ```options.payload``` is overrided, and thus we cannot set several key settings via ```x-hapi-options``` such as ```payload.parse```, ```payload.maxBytes```, ...

This PR allow this customisation.

Note: It also disable all validations if ```parse``` is ```false```, since the content may not be parseable, we cannot validate it