### PR TITLE
Added prefixBasePath to docs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The plugin will be registered as `openapi` on `server.plugins` with the followin
     - `path` - the path to expose api docs for swagger-ui, etc. Defaults to `/api-docs`.
     - `auth` - options auth config for this route.
     - `stripExtensions` - strip vendor extensions from docs. Defaults to true.
+    - `prefixBasePath` - prefix path of docs with he OpenAPI document's `basePath` value. Defaults to true.
 - `handlers` - either a string directory structure for route handlers, object, or not set if using `x-hapi-handler`.
 - `extensions` - an array of file extension types to use when scanning for handlers. Defaults to `['js']`.
 - `vhost` - *optional* domain string (see [hapi route options](http://hapijs.com/api#route-options)).
@@ -85,7 +86,7 @@ The plugin will be registered as `openapi` on `server.plugins` with the followin
 
 ### Mount Path
 
-Api `path` values will be prefixed with the OpenAPI document's `basePath` value.
+Api `path` values will be prefixed with the OpenAPI document's `basePath` value.  This behavior can be negated if you set the option `docs.prefixBasePath` to `false`.
 
 ### Handlers Directory
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,8 @@ const optionsSchema = Joi.object({
     docs: Joi.object({
         path: Joi.string().default('/api-docs'),
         auth: Joi.alternatives().try(Joi.object(), Joi.boolean()).allow(null),
-        stripExtensions: Joi.boolean().default(true)
+        stripExtensions: Joi.boolean().default(true),
+        prefixBasePath: Joi.boolean().default(true)
     }).default(),
     cors: Joi.boolean().default(true),
     vhost: Joi.string().allow(null),
@@ -72,7 +73,6 @@ const register = async function (server, options, next) {
 
     const { api, cors, vhost, handlers, extensions, outputvalidation } = validation.value;
     let { docs, docspath } = validation.value;
-
     const spec = await Parser.validate(api);
 
     spec.basePath = Utils.unsuffix(Utils.prefix(spec.basePath || '/', '/'), '/');
@@ -132,14 +132,17 @@ const register = async function (server, options, next) {
     if (docspath !== '/api-docs' && docs.path === '/api-docs') {
         server.log(['warn'], 'docspath is deprecated. Use docs instead.');
         docs = {
-            path: docspath
+            path: docspath,
+            prefixBasePath: docs.prefixBasePath
         };
     }
 
-    docs.path = Utils.prefix(docs.path, '/');
-    docs.path = Utils.unsuffix(docs.path, '/');
-
-    const apiPath = spec.basePath + docs.path;
+    let apiPath = docs.path;
+    if (docs.prefixBasePath){
+        docs.path = Utils.prefix(docs.path, '/');
+        docs.path = Utils.unsuffix(docs.path, '/');
+        apiPath = spec.basePath + docs.path;
+    }
 
     if (docs.stripExtensions) {
         apiDocument = stripVendorExtensions(apiDocument);

--- a/test/test-hapi-openapi.js
+++ b/test/test-hapi-openapi.js
@@ -5,9 +5,9 @@ const Path = require('path');
 const OpenAPI = require('../lib');
 const Hapi = require('hapi');
 
-Test('test plugin', function (t) {
+Test('test plugin', (t) => {
 
-    t.test('register', async function (t) {
+    t.test('register', async (t) => {
         t.plan(3);
 
         const server = new Hapi.Server();
@@ -33,7 +33,7 @@ Test('test plugin', function (t) {
 
     });
 
-    t.test('register with object api', async function (t) {
+    t.test('register with object api', async (t) => {
         t.plan(3);
 
         const server = new Hapi.Server();
@@ -88,13 +88,13 @@ Test('test plugin', function (t) {
             t.strictEqual(server.plugins.openapi.getApi().host, 'api.paypal.com', 'server.plugins.openapi.setHost set host.');
         }
         catch (error) {
-            console.log(error.stack)
+            console.log(error.stack);
             t.fail(error.message);
         }
 
     });
 
-    t.test('api docs', async function (t) {
+    t.test('api docs', async (t) => {
         t.plan(3);
 
         const server = new Hapi.Server();
@@ -125,7 +125,7 @@ Test('test plugin', function (t) {
         }
     });
 
-    t.test('api docs strip vendor extensions false', async function (t) {
+    t.test('api docs strip vendor extensions false', async (t) => {
         t.plan(3);
 
         const server = new Hapi.Server();
@@ -159,7 +159,7 @@ Test('test plugin', function (t) {
         }
     });
 
-    t.test('api docs auth false', async function (t) {
+    t.test('api docs auth false', async (t) => {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -188,7 +188,7 @@ Test('test plugin', function (t) {
         }
     });
 
-    t.test('api docs change path', async function (t) {
+    t.test('api docs change path (with basepath prefix)', async (t) => {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -217,7 +217,38 @@ Test('test plugin', function (t) {
         }
     });
 
-    t.test('api docs change path old way', async function (t) {
+    t.test('api docs change path (without basepath prefix)', async (t) => {
+        t.plan(1);
+
+        const server = new Hapi.Server();
+
+        try {
+            await server.register({
+                plugin: OpenAPI,
+                options: {
+                    api: Path.join(__dirname, './fixtures/defs/pets.json'),
+                    handlers: Path.join(__dirname, './fixtures/handlers'),
+                    docs: {
+                        path: '/spec',
+                        prefixBasePath: false
+                    }
+                }
+            });
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/spec'
+            });
+
+            t.strictEqual(response.statusCode, 200, `${response.request.path} OK.`);
+        }
+        catch (error) {
+            t.fail(error.message);
+        }
+    });
+
+
+    t.test('api docs change path old way', async (t) => {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -244,7 +275,7 @@ Test('test plugin', function (t) {
         }
     });
 
-    t.test('minimal api spec support', async function (t) {
+    t.test('minimal api spec support', async (t) => {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -283,7 +314,7 @@ Test('test plugin', function (t) {
                 }
             });
 
-            let response = await server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/test'
             });
@@ -297,7 +328,7 @@ Test('test plugin', function (t) {
 
     });
 
-    t.test('trailing slashes', async function (t) {
+    t.test('trailing slashes', async (t) => {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -336,7 +367,7 @@ Test('test plugin', function (t) {
                 }
             });
 
-            let response = await server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/test/'
             });
@@ -350,7 +381,7 @@ Test('test plugin', function (t) {
 
     });
 
-    t.test('routes', async function (t) {
+    t.test('routes', async (t) => {
         t.plan(5);
 
         const server = new Hapi.Server();
@@ -413,7 +444,7 @@ Test('test plugin', function (t) {
 
     });
 
-    t.test('routes with output validation', async function (t) {
+    t.test('routes with output validation', async (t) => {
         t.plan(5);
 
         const server = new Hapi.Server();
@@ -477,7 +508,7 @@ Test('test plugin', function (t) {
 
     });
 
-    t.test('output validation fails', async function (t) {
+    t.test('output validation fails', async (t) => {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -514,7 +545,7 @@ Test('test plugin', function (t) {
 
     });
 
-    t.test('routes x-handler', async function (t) {
+    t.test('routes x-handler', async (t) => {
         t.plan(4);
 
         const server = new Hapi.Server();
@@ -567,7 +598,7 @@ Test('test plugin', function (t) {
     });
 
 
-    t.test('query validation', async function (t) {
+    t.test('query validation', async (t) => {
 
         const server = new Hapi.Server();
 
@@ -586,7 +617,7 @@ Test('test plugin', function (t) {
                 'tags=single_tag': 200,
                 'limit=2&tags=some_tag&tags=some_other_tag': 200,
                 'limit=a_string': 400
-            }
+            };
 
             for (const queryString in queryStringToStatusCode) {
                 const response = await server.inject({
@@ -604,7 +635,7 @@ Test('test plugin', function (t) {
         }
     });
 
-    t.test('query validation with arrays', async function (t) {
+    t.test('query validation with arrays', async (t) => {
 
         const server = new Hapi.Server();
 
@@ -670,8 +701,8 @@ Test('test plugin', function (t) {
         }
     });
 
-    t.test('parse description from api definition', async function(t) {
-        t.test('do not break with empty descriptions', async function(t) {
+    t.test('parse description from api definition', async (t) => {
+        t.test('do not break with empty descriptions', async (t) => {
             t.plan(1);
 
             const server = new Hapi.Server();
@@ -715,7 +746,7 @@ Test('test plugin', function (t) {
             }
         });
 
-        t.test('create the right description for the route', async function(t) {
+        t.test('create the right description for the route', async (t) => {
             t.plan(1);
 
             const server = new Hapi.Server();
@@ -761,7 +792,7 @@ Test('test plugin', function (t) {
         });
     });
 
-    t.test('hapi payload options (assert via parse:false)', async function (t) {
+    t.test('hapi payload options (assert via parse:false)', async (t) => {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -819,7 +850,7 @@ Test('test plugin', function (t) {
                 }
             });
 
-            let response = await server.inject({
+            const response = await server.inject({
                 method: 'POST',
                 url: '/test',
                 payload: {
@@ -838,7 +869,7 @@ Test('test plugin', function (t) {
 
 });
 
-Test('multi-register', function (t) {
+Test('multi-register', (t) => {
 
     const api1 = {
         swagger: '2.0',
@@ -880,7 +911,7 @@ Test('multi-register', function (t) {
         }
     };
 
-    t.test('support register multiple', async function (t) {
+    t.test('support register multiple', async (t) => {
         t.plan(2);
 
         const server = new Hapi.Server();
@@ -936,7 +967,7 @@ Test('multi-register', function (t) {
 
     });
 
-    t.test('support fail on conflicts', async function (t) {
+    t.test('support fail on conflicts', async (t) => {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -987,8 +1018,8 @@ Test('multi-register', function (t) {
 
 });
 
-Test('yaml support', function (t) {
-    t.test('register', async function (t) {
+Test('yaml support', (t) => {
+    t.test('register', async (t) => {
         t.plan(3);
 
         const server = new Hapi.Server();

--- a/test/test-hapi-openapi.js
+++ b/test/test-hapi-openapi.js
@@ -5,7 +5,7 @@ const Path = require('path');
 const OpenAPI = require('../lib');
 const Hapi = require('hapi');
 
-Test('test plugin', (t) => {
+Test('test plugin', function (t) {
 
     t.test('register', async function (t) {
         t.plan(3);
@@ -868,7 +868,7 @@ Test('test plugin', (t) => {
 
 });
 
-Test('multi-register', (t) => {
+Test('multi-register', function (t) {
 
     const api1 = {
         swagger: '2.0',
@@ -1017,7 +1017,7 @@ Test('multi-register', (t) => {
 
 });
 
-Test('yaml support', (t) => {
+Test('yaml support', function (t) {
     t.test('register', async function (t) {
         t.plan(3);
 

--- a/test/test-hapi-openapi.js
+++ b/test/test-hapi-openapi.js
@@ -7,7 +7,7 @@ const Hapi = require('hapi');
 
 Test('test plugin', (t) => {
 
-    t.test('register', async (t) => {
+    t.test('register', async function (t) {
         t.plan(3);
 
         const server = new Hapi.Server();
@@ -33,7 +33,7 @@ Test('test plugin', (t) => {
 
     });
 
-    t.test('register with object api', async (t) => {
+    t.test('register with object api', async function (t) {
         t.plan(3);
 
         const server = new Hapi.Server();
@@ -88,13 +88,13 @@ Test('test plugin', (t) => {
             t.strictEqual(server.plugins.openapi.getApi().host, 'api.paypal.com', 'server.plugins.openapi.setHost set host.');
         }
         catch (error) {
-            console.log(error.stack);
+            console.log(error.stack)
             t.fail(error.message);
         }
 
     });
 
-    t.test('api docs', async (t) => {
+    t.test('api docs', async function (t) {
         t.plan(3);
 
         const server = new Hapi.Server();
@@ -125,7 +125,7 @@ Test('test plugin', (t) => {
         }
     });
 
-    t.test('api docs strip vendor extensions false', async (t) => {
+    t.test('api docs strip vendor extensions false', async function (t) {
         t.plan(3);
 
         const server = new Hapi.Server();
@@ -159,7 +159,7 @@ Test('test plugin', (t) => {
         }
     });
 
-    t.test('api docs auth false', async (t) => {
+    t.test('api docs auth false', async function (t) {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -188,7 +188,7 @@ Test('test plugin', (t) => {
         }
     });
 
-    t.test('api docs change path (with basepath prefix)', async (t) => {
+    t.test('api docs change path', async function (t) {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -217,7 +217,7 @@ Test('test plugin', (t) => {
         }
     });
 
-    t.test('api docs change path (without basepath prefix)', async (t) => {
+    t.test('api docs change path (with no basepath prefix)', async function (t) {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -230,7 +230,7 @@ Test('test plugin', (t) => {
                     handlers: Path.join(__dirname, './fixtures/handlers'),
                     docs: {
                         path: '/spec',
-                        prefixBasePath: false
+						prefixBasePath: false
                     }
                 }
             });
@@ -247,8 +247,7 @@ Test('test plugin', (t) => {
         }
     });
 
-
-    t.test('api docs change path old way', async (t) => {
+    t.test('api docs change path old way', async function (t) {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -275,7 +274,7 @@ Test('test plugin', (t) => {
         }
     });
 
-    t.test('minimal api spec support', async (t) => {
+    t.test('minimal api spec support', async function (t) {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -314,7 +313,7 @@ Test('test plugin', (t) => {
                 }
             });
 
-            const response = await server.inject({
+            let response = await server.inject({
                 method: 'GET',
                 url: '/test'
             });
@@ -328,7 +327,7 @@ Test('test plugin', (t) => {
 
     });
 
-    t.test('trailing slashes', async (t) => {
+    t.test('trailing slashes', async function (t) {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -367,7 +366,7 @@ Test('test plugin', (t) => {
                 }
             });
 
-            const response = await server.inject({
+            let response = await server.inject({
                 method: 'GET',
                 url: '/test/'
             });
@@ -381,7 +380,7 @@ Test('test plugin', (t) => {
 
     });
 
-    t.test('routes', async (t) => {
+    t.test('routes', async function (t) {
         t.plan(5);
 
         const server = new Hapi.Server();
@@ -444,7 +443,7 @@ Test('test plugin', (t) => {
 
     });
 
-    t.test('routes with output validation', async (t) => {
+    t.test('routes with output validation', async function (t) {
         t.plan(5);
 
         const server = new Hapi.Server();
@@ -508,7 +507,7 @@ Test('test plugin', (t) => {
 
     });
 
-    t.test('output validation fails', async (t) => {
+    t.test('output validation fails', async function (t) {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -545,7 +544,7 @@ Test('test plugin', (t) => {
 
     });
 
-    t.test('routes x-handler', async (t) => {
+    t.test('routes x-handler', async function (t) {
         t.plan(4);
 
         const server = new Hapi.Server();
@@ -598,7 +597,7 @@ Test('test plugin', (t) => {
     });
 
 
-    t.test('query validation', async (t) => {
+    t.test('query validation', async function (t) {
 
         const server = new Hapi.Server();
 
@@ -617,7 +616,7 @@ Test('test plugin', (t) => {
                 'tags=single_tag': 200,
                 'limit=2&tags=some_tag&tags=some_other_tag': 200,
                 'limit=a_string': 400
-            };
+            }
 
             for (const queryString in queryStringToStatusCode) {
                 const response = await server.inject({
@@ -635,7 +634,7 @@ Test('test plugin', (t) => {
         }
     });
 
-    t.test('query validation with arrays', async (t) => {
+    t.test('query validation with arrays', async function (t) {
 
         const server = new Hapi.Server();
 
@@ -701,8 +700,8 @@ Test('test plugin', (t) => {
         }
     });
 
-    t.test('parse description from api definition', async (t) => {
-        t.test('do not break with empty descriptions', async (t) => {
+    t.test('parse description from api definition', async function(t) {
+        t.test('do not break with empty descriptions', async function(t) {
             t.plan(1);
 
             const server = new Hapi.Server();
@@ -746,7 +745,7 @@ Test('test plugin', (t) => {
             }
         });
 
-        t.test('create the right description for the route', async (t) => {
+        t.test('create the right description for the route', async function(t) {
             t.plan(1);
 
             const server = new Hapi.Server();
@@ -792,7 +791,7 @@ Test('test plugin', (t) => {
         });
     });
 
-    t.test('hapi payload options (assert via parse:false)', async (t) => {
+    t.test('hapi payload options (assert via parse:false)', async function (t) {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -850,7 +849,7 @@ Test('test plugin', (t) => {
                 }
             });
 
-            const response = await server.inject({
+            let response = await server.inject({
                 method: 'POST',
                 url: '/test',
                 payload: {
@@ -911,7 +910,7 @@ Test('multi-register', (t) => {
         }
     };
 
-    t.test('support register multiple', async (t) => {
+    t.test('support register multiple', async function (t) {
         t.plan(2);
 
         const server = new Hapi.Server();
@@ -967,7 +966,7 @@ Test('multi-register', (t) => {
 
     });
 
-    t.test('support fail on conflicts', async (t) => {
+    t.test('support fail on conflicts', async function (t) {
         t.plan(1);
 
         const server = new Hapi.Server();
@@ -1019,7 +1018,7 @@ Test('multi-register', (t) => {
 });
 
 Test('yaml support', (t) => {
-    t.test('register', async (t) => {
+    t.test('register', async function (t) {
         t.plan(3);
 
         const server = new Hapi.Server();


### PR DESCRIPTION
We need the ability to put the docs at a path that is not rooted at the basePath of the swagger spec.

see https://github.com/krakenjs/hapi-openapi/issues/149
closes #149 