### PR TITLE
Fixes #151

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -163,7 +163,7 @@ const create = function (options = {}) {
                     break;
                 case 'path':
                     validate.params = validate.params || {};
-                    validate.params[validator.parameter.name.replace(/\*[0-9]*$/, '')] = validator.schema;
+                    validate.params[validator.parameter.name.replace(/(\*[0-9]*|\?)$/, '')] = validator.schema;
                     routeExt.push(validator.routeExt);
                     break;
                 case 'body':

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -163,7 +163,7 @@ const create = function (options = {}) {
                     break;
                 case 'path':
                     validate.params = validate.params || {};
-                    validate.params[validator.parameter.name] = validator.schema;
+                    validate.params[validator.parameter.name.replace(/\*[0-9]*$/, '')] = validator.schema;
                     routeExt.push(validator.routeExt);
                     break;
                 case 'body':

--- a/test/test-validators.js
+++ b/test/test-validators.js
@@ -1,66 +1,98 @@
 const Test = require('tape');
 const Validators = require('../lib/validators');
 
-Test('validator special types', function (t) {
-    const api = {
-        swagger: '2.0',
-        info: {
-            title: 'Minimal',
-            version: '1.0.0'
-        },
-        paths: {
-            '/test': {
-                get: {
-                    description: '',
-                    parameters: [
-                        {
-                            name: 'dateTime',
-                            in: 'query',
-                            required: false,
-                            type: 'string',
-                            format: 'date-time'
-                        }
-                    ],
-                    responses: {
-                        200: {
-                            description: 'default response'
-                        }
-                    }
-                }
+Test('validator special types', function(t) {
+  const api = {
+    swagger: '2.0',
+    info: {
+      title: 'Minimal',
+      version: '1.0.0'
+    },
+    paths: {
+      '/test': {
+        get: {
+          description: '',
+          parameters: [
+            {
+              name: 'dateTime',
+              in: 'query',
+              required: false,
+              type: 'string',
+              format: 'date-time'
             }
+          ],
+          responses: {
+            200: {
+              description: 'default response'
+            }
+          }
         }
-    };
-    
-    const validator = Validators.create(api);
-
-    t.test('valid date-time', async function (t) {
-        t.plan(1);
-
-        const { validate } = validator.makeValidator(api.paths['/test'].get.parameters[0]);
-
-        try {
-            await validate('1995-09-07T10:40:52Z');
-            t.pass('valid date-time');
+      },
+      '/test/{foo*}': {
+        get: {
+          description: '',
+          parameters: [
+            {
+              name: 'foo*',
+              in: 'path',
+              required: true,
+              type: 'string'
+            }
+          ],
+          responses: {
+            200: {
+              description: 'default response'
+            }
+          }
         }
-        catch (error) {
-            t.fail(error.message);
-        }
-    });
+      }
+    }
+  };
 
-    t.test('invalid date-time', async function (t) {
-        t.plan(1);
+  const validator = Validators.create(api);
 
-        const { validate } = validator.makeValidator(api.paths['/test'].get.parameters[0]);
+  t.test('valid date-time', async function(t) {
+    t.plan(1);
 
-        const timestamp = Date.now();
+    const { validate } = validator.makeValidator(
+      api.paths['/test'].get.parameters[0]
+    );
 
-        try {
-            await validate(timestamp);
-            t.fail(`${timestamp} should be invalid.`);
-        }
-        catch (error) {
-            t.pass(`${timestamp} is invalid.`);
-        }
-    });
+    try {
+      await validate('1995-09-07T10:40:52Z');
+      t.pass('valid date-time');
+    } catch (error) {
+      t.fail(error.message);
+    }
+  });
 
+  t.test('invalid date-time', async function(t) {
+    t.plan(1);
+
+    const { validate } = validator.makeValidator(
+      api.paths['/test'].get.parameters[0]
+    );
+
+    const timestamp = Date.now();
+
+    try {
+      await validate(timestamp);
+      t.fail(`${timestamp} should be invalid.`);
+    } catch (error) {
+      t.pass(`${timestamp} is invalid.`);
+    }
+  });
+
+  t.test('validate multi-segment paths', async function(t) {
+    t.plan(1);
+
+    const v = validator.makeAll(api.paths['/test/{foo*}'].get.parameters);
+
+    const keys = Object.keys(v.validate.params);
+
+    if (keys.length === 1 && keys[0] === 'foo') {
+      return t.pass(`${keys.join(', ')} are valid.`);
+    }
+    t.fail(`${keys.join(', ')} are invalid.`);
+  });
 });


### PR DESCRIPTION
If you have a multi-segment path defined (/api/v1/proxy/{path*}) it breaks when it creates the validator due to it creating the param name as "path*" instead of "path". As multi-segment parameters can also have a repeat variable (path*2 as example) replacing the path variable name needs to take this into account.