### PR TITLE
Feature/Support for custom operation tags

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -43,12 +43,13 @@ const create = async function (server, { api, basedir, cors, vhost, handlers, ex
                 continue;
             }
 
+            const customTags = operation.tags || [];
             const options = Object.assign({
                 cors,
                 id: operation.operationId,
                 // hapi does not support empty descriptions
                 description: operation.description !== '' ? operation.description : undefined,
-                tags: ['api']
+                tags: ['api', ...customTags]
             }, xoptions);
 
             options.handler = handler;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hapi-openapi",
   "description": "Design-driven apis with OpenAPI (formerly Swagger) 2.0 and hapi.",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": "Trevor Livingston <tlivings@gmail.com>",
   "repository": {
     "type": "git",

--- a/test/test-hapi-openapi.js
+++ b/test/test-hapi-openapi.js
@@ -925,6 +925,120 @@ Test('test plugin', function (t) {
 
     });
 
+    t.test('hapi operation tags', async function (t) {
+        t.plan(1);
+
+        const server = new Hapi.Server();
+
+        const api = {
+            swagger: '2.0',
+            info: {
+                title: 'Minimal',
+                version: '1.0.0'
+            },
+            paths: {
+                '/test': {
+                    get: {
+                        tags: [
+                            'sample1',
+                            'sample2'
+                        ],
+                        responses: {
+                            200: {
+                                description: 'default response'
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const expectedTags = ['api', 'sample1', 'sample2']
+
+        try {
+            await server.register({
+                plugin: OpenAPI,
+                options: {
+                    api,
+                    handlers: {
+                        test: {
+                            get() {
+                                return 'test';
+                            }
+                        }
+                    }
+                }
+            });
+
+            let response = await server.inject({
+                method: 'GET',
+                url: '/test'
+            });
+            const responsteTags = response.request.route.settings.tags
+
+            t.deepEqual(responsteTags, expectedTags, 'additional tags successfully configured');
+
+        }
+        catch (error) {
+            t.fail(error.message);
+        }
+
+    });
+
+    t.test('hapi operation tags omitted', async function (t) {
+        t.plan(1);
+
+        const server = new Hapi.Server();
+
+        const api = {
+            swagger: '2.0',
+            info: {
+                title: 'Minimal',
+                version: '1.0.0'
+            },
+            paths: {
+                '/test': {
+                    get: {
+                        responses: {
+                            200: {
+                                description: 'default response'
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        const expectedDefaultTags = ['api']
+
+        try {
+            await server.register({
+                plugin: OpenAPI,
+                options: {
+                    api,
+                    handlers: {
+                        test: {
+                            get() {
+                                return 'test';
+                            }
+                        }
+                    }
+                }
+            });
+
+            let response = await server.inject({
+                method: 'GET',
+                url: '/test'
+            });
+            const responsteTags = response.request.route.settings.tags
+
+            t.deepEqual(responsteTags, expectedDefaultTags, 'returned default tags');
+
+        }
+        catch (error) {
+            t.fail(error.message);
+        }
+
+    });
+
 });
 
 Test('multi-register', function (t) {


### PR DESCRIPTION
For tracing purposes we need to be able to define operation tags, but current implementation overwrites what's been defined. This PR resolves the issue. Not sure about the category: feature or bugfix.
Please, review.
Thanks!