### PR TITLE
fix(validation): respect `allowUnknown` route property

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -73,7 +73,8 @@ const create = async function (server, { api, basedir, cors, vhost, handlers, ex
             const skipValidation = options.payload && options.payload.parse === false;
 
             if (operation.parameters && !skipValidation) {
-                const v = validator.makeAll(operation.parameters, operation.consumes || api.consumes);
+                const allowUnknownProperties = xoptions.validate && xoptions.validate.options && xoptions.validate.options.allowUnknown === true;
+                const v = validator.makeAll(operation.parameters, operation.consumes || api.consumes, allowUnknownProperties);
                 options.validate = v.validate;
                 options.ext = {
                     onPreAuth: { method: v.routeExt }

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -40,13 +40,13 @@ const enjoi = Enjoi.defaults({ types, refineType });
 
 const create = function (options = {}) {
 
-    const makeValidator = function (parameter, consumes) {
+    const makeValidator = function (parameter, consumes, allowUnknownProperties = false) {
         const coerce = coercion(parameter, consumes);
 
         let schema;
 
         if ((parameter.in === 'body' || parameter.in === 'formData') && parameter.schema) {
-            schema = enjoi.schema(parameter.schema);
+            schema = enjoi.schema(parameter.schema).unknown(allowUnknownProperties);
         }
         else {
             const template = {
@@ -96,6 +96,7 @@ const create = function (options = {}) {
             },
             validate: async function (value) {
                 const data = coerce && value && coerce(value);
+                console.log('validation data: %j', data);
                 const result = await schema.validate(data);
 
                 if (result.error) {
@@ -132,7 +133,7 @@ const create = function (options = {}) {
         return schemas;
     };
 
-    const makeAll = function (parameters = [], consumes) {
+    const makeAll = function (parameters = [], consumes, allowUnknownProperties = false) {
         const routeExt = [];
         const validate = {};
         const formValidators = {};
@@ -149,7 +150,7 @@ const create = function (options = {}) {
         };
 
         for (const parameter of parameters) {
-            const validator = makeValidator(parameter, consumes);
+            const validator = makeValidator(parameter, consumes, allowUnknownProperties);
 
             switch (validator.parameter.in) {
                 case 'header':


### PR DESCRIPTION
This ensures it is possible to allow unknown properties in request bodies (Postel’s Law), by respecting the `x-hapi-options` option.

---

**Discussion**

In general, one could consider making `allowUnknown: true` the default behavior, but I guess that would be considered a breaking change.

*Some notes from the thought processes around this change*:

* The server wide route option (where this could be set) is apparently not respected by hapi-openapi (probably because validation is overwritten?). Otherwise, that would've been a nice way to avoid this custom property.
* Just providing the validation option does not seem to cut it, since `options.validator` is overwritten. Avoiding overwriting the provided option (`options.validate = Object.assign({}, v.validate, options.validate);` did not solve the problem. Hence, I decided to make it an explicit option that trickled down the creation of the validator.
* I decided not to strip the unknown properties, because it's a different property in Hapi (and not necessarily wanted just because unknowns are allowed).

If there's a better way to solve this, I'm all ears, but this was fairly straightforward and did solve the issue.