### PR TITLE
Upgrade dependencies to support hapi 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "8"
-  - "10"
+  - "12"
   - "stable"
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hapi-openapi
 
-[![Build Status](https://travis-ci.org/krakenjs/hapi-openapi.svg?branch=master)](https://travis-ci.org/krakenjs/hapi-openapi)  
-[![NPM version](https://badge.fury.io/js/hapi-openapi.png)](http://badge.fury.io/js/hapi-openapi)  
+[![Build Status](https://travis-ci.org/krakenjs/hapi-openapi.svg?branch=master)](https://travis-ci.org/krakenjs/hapi-openapi)
+[![NPM version](https://badge.fury.io/js/hapi-openapi.png)](http://badge.fury.io/js/hapi-openapi)
 
 ### Note: this project was renamed from 'swaggerize-hapi' to 'hapi-openapi'.
 
@@ -49,7 +49,7 @@ You now have a working api and can use something like [SwaggerHub](https://swagg
 ### Manual Usage
 
 ```javascript
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = new Hapi.Server();
 
@@ -194,7 +194,7 @@ This will construct a `handlers` object from the given `x-hapi-handler` files.
 
 ### X-Hapi-Options
 
-There is now support at the operations level for `x-hapi-options` which represent individual [Hapi Route Optijons](https://github.com/hapijs/hapi/blob/master/API.md#route-options). 
+There is now support at the operations level for `x-hapi-options` which represent individual [Hapi Route Optijons](https://github.com/hapijs/hapi/blob/master/API.md#route-options).
 
 This support is limited to configuration supported by the JSON file type.
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ and
 ```javascript
 //xauth-strategy.js
 
-const Boom = require('boom');
+const Boom = require('@hapi/boom');
 
 const register = function (server, { name, scheme, where, lookup }) {
     server.auth.strategy(name, /* the scheme to use this strategy with */ scheme, {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Package = require('../package.json');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const Hoek = require('hoek');
 const Caller = require('./caller');
 const Path = require('path');
@@ -164,7 +164,7 @@ const register = async function (server, options, next) {
         },
         vhost
     });
-    
+
     const routes = await Routes.create(server, { api: spec, basedir, cors, vhost, handlers, extensions, outputvalidation });
 
     for (const route of routes) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 const Package = require('../package.json');
 const Joi = require('@hapi/joi');
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const Caller = require('./caller');
 const Path = require('path');
 const Parser = require('swagger-parser');

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -2,7 +2,7 @@
 
 const ObjectFiles = require('merge-object-files');
 const Validators = require('./validators');
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const Utils = require('./utils');
 const Path = require('path');
 const Props = require('dot-prop');

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -94,11 +94,6 @@ const create = async function (server, { api, basedir, cors, vhost, handlers, ex
                     const securitySchemes = Object.keys(secdef);
 
                     for (const securityDefinitionName of securitySchemes) {
-                        if (!server.auth._strategies[securityDefinitionName]) {
-                            server.log(['warn'], `${securityDefinitionName} strategy was not registered.`);
-                            continue;
-                        }
-
                         const securityDefinition = api.securityDefinitions[securityDefinitionName];
 
                         Hoek.assert(securityDefinition, 'Security scheme not defined.');

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -140,7 +140,7 @@ const create = function (options = {}) {
 
         const formValidator = async function (value) {
             const result = await this.validate(value);
-            
+
             if (result.error) {
                 throw result.error;
             }
@@ -190,6 +190,12 @@ const create = function (options = {}) {
 
                     return results;
                 };
+            }
+        }
+
+        for (const [key, value] of Object.entries(validate)) {
+            if (typeof value === 'object' && !value.isJoi) {
+                validate[key] = Joi.object(value);
             }
         }
 

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Enjoi = require('enjoi');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const Util = require('util');
 
 const types = {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.4",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "swagger-parser": "^9.0.1"
   },
   "devDependencies": {
+    "@hapi/boom": "^9.1.0",
     "@hapi/hapi": "^19.1.1",
-    "boom": "^7.2.0",
     "eslint": "^4.19.1",
     "eslint-config-hapi": "^11.1.0",
     "eslint-plugin-hapi": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "node": ">=8"
   },
   "dependencies": {
+    "@hapi/hoek": "^9.0.4",
     "@hapi/joi": "^15.1.1",
     "dot-prop": "^4.2.0",
     "enjoi": "^6.0.1",
-    "hoek": "^5.0.3",
     "js-yaml": "^3.11.0",
     "merge-object-files": "^2.0.0",
     "swagger-parser": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "swagger-parser": "^4.1.0"
   },
   "devDependencies": {
+    "@hapi/hapi": "^19.1.1",
     "boom": "^7.2.0",
     "eslint": "^4.19.1",
     "eslint-config-hapi": "^11.1.0",
     "eslint-plugin-hapi": "^4.1.0",
-    "hapi": "^17.4.0",
     "nyc": "^13.3.0",
     "tape": "^4.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint": "^4.19.1",
     "eslint-config-hapi": "^11.1.0",
     "eslint-plugin-hapi": "^4.1.0",
-    "nyc": "^13.3.0",
+    "nyc": "^15.0.0",
     "tape": "^4.9.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "enjoi": "^6.0.1",
     "js-yaml": "^3.11.0",
     "merge-object-files": "^2.0.0",
-    "swagger-parser": "^4.1.0"
+    "swagger-parser": "^9.0.1"
   },
   "devDependencies": {
     "@hapi/hapi": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "node": ">=8"
   },
   "dependencies": {
+    "@hapi/joi": "^15.1.1",
     "dot-prop": "^4.2.0",
-    "enjoi": "^4.0.0",
+    "enjoi": "^6.0.1",
     "hoek": "^5.0.3",
-    "joi": "^13.6.0",
     "js-yaml": "^3.11.0",
     "merge-object-files": "^2.0.0",
     "swagger-parser": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
-    "@hapi/joi": "^15.1.1",
+    "@hapi/joi": "^14.5.0",
     "dot-prop": "^4.2.0",
     "enjoi": "^6.0.1",
     "js-yaml": "^3.11.0",

--- a/test/fixtures/lib/stub-auth-token-scheme.js
+++ b/test/fixtures/lib/stub-auth-token-scheme.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Boom = require('boom');
+var Boom = require('@hapi/boom');
 
 const register = function (server, options) {
     server.auth.scheme('stub-auth-token', function (server, options) {

--- a/test/fixtures/lib/xauth-scheme.js
+++ b/test/fixtures/lib/xauth-scheme.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Boom = require('boom');
+var Boom = require('@hapi/boom');
 
 const register = function (server, { name  }) {
     server.auth.scheme(name /*apiKey*/, (server, { validate }) => {

--- a/test/fixtures/lib/xauth-strategy.js
+++ b/test/fixtures/lib/xauth-strategy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Boom = require('boom');
+const Boom = require('@hapi/boom');
 
 const register = function (server, { name, scheme, where, lookup }) {
     server.auth.strategy(name, scheme, {

--- a/test/test-auth.js
+++ b/test/test-auth.js
@@ -3,7 +3,7 @@
 const Test = require('tape');
 const Path = require('path');
 const OpenAPI = require('../lib');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const StubAuthTokenScheme = require('./fixtures/lib/stub-auth-token-scheme');
 
 Test('authentication', function (t) {
@@ -80,6 +80,10 @@ Test('authentication', function (t) {
                 }
             });
 
+            server.auth.strategy('api_key2', 'stub-auth-token', {
+                validateFunc: () => ({ isValid: true })
+            });
+
             await server.register({
                 plugin: OpenAPI,
                 options: {
@@ -115,6 +119,10 @@ Test('authentication', function (t) {
                 validateFunc: async function (token) {
                     return { credentials: { scope: [ 'api3:read' ] }, artifacts: { }};
                 }
+            });
+
+            server.auth.strategy('api_key2', 'stub-auth-token', {
+                validateFunc: () => ({ isValid: true })
             });
 
             await server.register({

--- a/test/test-forms.js
+++ b/test/test-forms.js
@@ -3,7 +3,7 @@
 const Test = require('tape');
 const Path = require('path');
 const OpenAPI = require('../lib');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 
 Test('form data', function (t) {

--- a/test/test-hapi-openapi.js
+++ b/test/test-hapi-openapi.js
@@ -3,7 +3,7 @@
 const Test = require('tape');
 const Path = require('path');
 const OpenAPI = require('../lib');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 Test('test plugin', function (t) {
 

--- a/test/test-validators.js
+++ b/test/test-validators.js
@@ -88,7 +88,7 @@ Test('validator special types', function(t) {
 
     const v = validator.makeAll(api.paths['/test/{foo*}'].get.parameters);
 
-    const keys = Object.keys(v.validate.params);
+    const keys = Object.keys(v.validate.params.describe().children);
 
     if (keys.length === 1 && keys[0] === 'foo') {
       return t.pass(`${keys.join(', ')} are valid.`);

--- a/test/test_xoptions.js
+++ b/test/test_xoptions.js
@@ -3,7 +3,7 @@
 const Test = require('tape');
 const Path = require('path');
 const OpenAPI = require('../lib');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 
 Test('x-hapi-options', function (t) {


### PR DESCRIPTION
**Description of changes:**
This PR updates several dependencies (list below). The hapi upgrade includes two important changes:

1. There is no longer a way to query the strategies registered with the server. The previous behavior allowed hapi-openapi to issue a warning that an auth strategy was not registered, then continue creating the route without the specified auth options. With this change, the route options will be added as long as they are specified. If the auth strategy is not registered, then an error will be thrown when registering the route. This seems to be inline with the existing text in README.md.

2. Hapi 19 no longer allows uncompiled top-level validation schemas unless a validator is configured with the server. In previous versions, Joi was used by default. To address this, after the validators are created for a path/operation, any top-level object that is not already a Joi schema is wrapped in Joi.object(). I went with this approach rather than setting a default validator on the server so that the host codebase could still have flexibility to use a different default validator for any routes that may be created outside hapi-openapi. 

**Dependencies upgraded:**
- hapi => v19
- joi => v14
- enjoi => v6
- hoek => v9
- swagger-parser => v9
- boom => v9
- nyc => v15

At the time of this PR, all vulnerabilities found with `npm audit` have been addressed.

**Issues addressed:**
This PR addresses or partially addresses the following issues:

- https://github.com/krakenjs/hapi-openapi/issues/171
- https://github.com/krakenjs/hapi-openapi/issues/170
- https://github.com/krakenjs/hapi-openapi/issues/163 (hapi only. joi must wait on enjoi to be updated)
- https://github.com/krakenjs/hapi-openapi/issues/148