### PR TITLE
Fixed failing `unknown` call for array schema

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Tape Current File",
+            "program": "${workspaceFolder}/node_modules/tape/bin/tape",
+            "args": [
+                "${file}"
+            ],
+            "console": "internalConsole"
+        }
+    ]
+}

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -46,7 +46,10 @@ const create = function (options = {}) {
         let schema;
 
         if ((parameter.in === 'body' || parameter.in === 'formData') && parameter.schema) {
-            schema = enjoi.schema(parameter.schema).unknown(allowUnknownProperties);
+            schema = enjoi.schema(parameter.schema);
+            if (schema.schemaType === 'object') {
+                schema = schema.unknown(allowUnknownProperties);
+            }
         }
         else {
             const template = {
@@ -96,7 +99,6 @@ const create = function (options = {}) {
             },
             validate: async function (value) {
                 const data = coerce && value && coerce(value);
-                console.log('validation data: %j', data);
                 const result = await schema.validate(data);
 
                 if (result.error) {

--- a/test/test-hapi-openapi.js
+++ b/test/test-hapi-openapi.js
@@ -289,7 +289,7 @@ Test('test plugin', function (t) {
                     handlers: Path.join(__dirname, './fixtures/handlers'),
                     docs: {
                         path: '/spec',
-						prefixBasePath: false
+                        prefixBasePath: false
                     }
                 }
             });
@@ -759,8 +759,8 @@ Test('test plugin', function (t) {
         }
     });
 
-    t.test('parse description from api definition', async function(t) {
-        t.test('do not break with empty descriptions', async function(t) {
+    t.test('parse description from api definition', async function (t) {
+        t.test('do not break with empty descriptions', async function (t) {
             t.plan(1);
 
             const server = new Hapi.Server();
@@ -804,7 +804,7 @@ Test('test plugin', function (t) {
             }
         });
 
-        t.test('create the right description for the route', async function(t) {
+        t.test('create the right description for the route', async function (t) {
             t.plan(1);
 
             const server = new Hapi.Server();
@@ -992,6 +992,89 @@ Test('test plugin', function (t) {
                     id: 'string-id',
                     excessive: 42
                 }
+            });
+
+            t.strictEqual(response.statusCode, 200, `${response.request.path} OK.`);
+
+        }
+        catch (error) {
+            t.fail(error.message);
+        }
+
+    });
+
+    t.test('hapi array parameters', async function (t) {
+        t.plan(1);
+
+        const server = new Hapi.Server();
+
+        const api = {
+            swagger: '2.0',
+            info: {
+                title: 'Minimal',
+                version: '1.0.0'
+            },
+            paths: {
+                '/test': {
+                    post: {
+                        parameters: [
+                            {
+                                name: 'body',
+                                in: 'body',
+                                schema: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            name: {
+                                                type: "string"
+                                            },
+                                            breed: {
+                                                type: "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        responses: {
+                            200: {
+                                description: 'default response'
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        try {
+            await server.register({
+                plugin: OpenAPI,
+                options: {
+                    api,
+                    handlers: {
+                        test: {
+                            post() {
+                                return 'test';
+                            }
+                        }
+                    }
+                }
+            });
+
+            let response = await server.inject({
+                method: 'POST',
+                url: '/test',
+                payload: [
+                    {
+                        name: 'Fido',
+                        breed: 'Pointer'
+                    },
+                    {
+                        name: 'Frodo',
+                        breed: 'Beagle'
+                    }
+                ]
             });
 
             t.strictEqual(response.statusCode, 200, `${response.request.path} OK.`);


### PR DESCRIPTION
After commit https://github.com/krakenjs/hapi-openapi/commit/429bfbfa53c8b8f1f5574f0e9447a3acdc669474, Joi object unknown method was called for all input schemas. This results in a runtime error for array input schema. This commit only invokes unknown method for object schema type. For convenience VS Code launch file to debug tape tests is also included.