### PR TITLE
Empty object coercion

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -100,7 +100,7 @@ const create = function (options = {}) {
                 const data = coerce && value && coerce(value);
                 const result = schema.validate(data);
 
-                if (result.error) {
+                if (result && result.error) {
 
                     result.error.message = result.error.message.replace('value', parameter.name);
 

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -96,9 +96,9 @@ const create = function (options = {}) {
                 request[p][parameter.name] = coerce && request[p][parameter.name] && coerce(request[p][parameter.name]);
                 return h.continue;
             },
-            validate: async function (value) {
+            validate: function (value) {
                 const data = coerce && value && coerce(value);
-                const result = await schema.validate(data);
+                const result = schema.validate(data);
 
                 if (result.error) {
 
@@ -140,8 +140,8 @@ const create = function (options = {}) {
         const formValidators = {};
         let headers = {};
 
-        const formValidator = async function (value) {
-            const result = await this.validate(value);
+        const formValidator = function (value) {
+            const result = this.validate(value);
 
             if (result.error) {
                 throw result.error;

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -2,7 +2,6 @@
 
 const Enjoi = require('enjoi');
 const Joi = require('@hapi/joi');
-const Util = require('util');
 
 const types = {
     int64: Joi.string().regex(/^\d+$/),
@@ -274,12 +273,7 @@ const coercion = function (parameter, consumes) {
     }
 
     if (!fn && parameter.schema) {
-        fn = function (data) {
-            if (Util.isObject(data) && !Object.keys(data).length) {
-                return undefined;
-            }
-            return data;
-        };
+        fn = (data) => data;
     }
 
     return fn;

--- a/test/test-validators.js
+++ b/test/test-validators.js
@@ -26,6 +26,25 @@ Test('validator special types', function(t) {
               description: 'default response'
             }
           }
+        },
+        post: {
+          description: '',
+          parameters: [
+            {
+              name: 'payload',
+              in: 'body',
+              required: true,
+              schema: {
+                type: 'object',
+                required: ['requiredProperty'],
+                properties: {
+                  requiredProperty: {
+                    type: 'string'
+                  }
+                }
+              }
+            }
+          ]
         }
       },
       '/test/{foo*}': {
@@ -59,7 +78,7 @@ Test('validator special types', function(t) {
     );
 
     try {
-      await validate('1995-09-07T10:40:52Z');
+      validate('1995-09-07T10:40:52Z');
       t.pass('valid date-time');
     } catch (error) {
       t.fail(error.message);
@@ -76,7 +95,7 @@ Test('validator special types', function(t) {
     const timestamp = Date.now();
 
     try {
-      await validate(timestamp);
+      validate(timestamp);
       t.fail(`${timestamp} should be invalid.`);
     } catch (error) {
       t.pass(`${timestamp} is invalid.`);
@@ -95,4 +114,30 @@ Test('validator special types', function(t) {
     }
     t.fail(`${keys.join(', ')} are invalid.`);
   });
+
+  t.test('validate missing body parameter', async function(t) {
+      t.plan(1);
+
+      const { validate } = validator.makeValidator(api.paths['/test'].post.parameters[0]);
+
+      try {
+          validate();
+          t.fail('"undefined" should be invalid');
+      } catch (error) {
+          t.equal(error.message, '"payload" is required', "received expected payload error message");
+      }
+  });
+
+  t.test('validate empty object with required property', async function(t) {
+      t.plan(1);
+
+      const { validate } = validator.makeValidator(api.paths['/test'].post.parameters[0]);
+
+      try {
+          validate({});
+          t.fail('"undefined" should be invalid');
+      } catch (error) {
+          t.match(error.message, /"requiredProperty" is required/, "received expected property error message");
+      }
+  })
 });


### PR DESCRIPTION
Addresses https://github.com/krakenjs/hapi-openapi/issues/166

Previously, two things were working together to create this result:

1. The `coercion` function would return `undefined` for an empty object or array value for body parameters (`parameter.schema` exists). 
2. The result of running the `coercion` function ('undefined' in this case) was sent to `schema.validate`. Because this function is `await`ed, the actual value is returned, and is subsequently inspected for an `error` property. Since the value is `undefined`, this throws an unexpected error.

The fix applied is:
1. Don't coerce empty objects or arrays into `undefined`. Just return the empty object/array. 
2. Don't `await` calls to `validate`. This is not as async function, so `await` is not needed. In this case, `await`ing validate caused `undefined` to be returned rather than an object with `value: undefined`, which led to the unexpected error.
3. Add a check to catch cases where the result of `validate` _is_ falsy for some reason, although this should not happen due to the other changes.

After applying this fix, cases where an `in: body` parameter is specified but not provided return a 400 with an error message resolving correctly to the parameter name.