### PR TITLE
Don't set undefined parameters on request in "routeExt"

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -93,7 +93,9 @@ const create = function (options = {}) {
             schema,
             routeExt: function (request, h) {
                 const p = parameter.in === 'query' ? 'query' : 'params';
-                request[p][parameter.name] = coerce && request[p][parameter.name] && coerce(request[p][parameter.name]);
+                if (request[p][parameter.name] !== undefined) {
+                    request[p][parameter.name] = coerce && request[p][parameter.name] && coerce(request[p][parameter.name]);
+                }
                 return h.continue;
             },
             validate: function (value) {

--- a/test/test-hapi-openapi.js
+++ b/test/test-hapi-openapi.js
@@ -153,6 +153,65 @@ Test('test plugin', function (t) {
 
     });
 
+    t.test('register with optional query parameters does not change "request.orig"', async function (t) {
+        t.plan(1);
+
+        const server = new Hapi.Server();
+
+        const api = {
+            swagger: '2.0',
+            info: {
+                title: 'Test Optional Query Params',
+                version: '1.0.0'
+            },
+            paths: {
+                '/test': {
+                    get: {
+                        parameters: [
+                            {
+                                name: 'optionalParameter',
+                                in: 'query',
+                                required: false,
+                                type: 'string',
+                            },
+                        ],
+                        responses: {
+                            200: {
+                                description: 'OK'
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        try {
+            await server.register({
+                plugin: OpenAPI,
+                options: {
+                    api,
+                    handlers: {
+                        test: {
+                            get(request, h) {
+                                return request.orig;
+                            }
+                        }
+                    }
+                }
+            });
+
+            const { result } = await server.inject({
+                method: 'GET',
+                url: '/test'
+            });
+
+            t.deepEqual(result.query, {}, 'request.orig was not modified');
+        }
+        catch (error) {
+            t.fail(error.message);
+        }
+    });
+
     t.test('api docs', async function (t) {
         t.plan(3);
 


### PR DESCRIPTION
Addresses https://github.com/krakenjs/hapi-openapi/issues/179

To prevent optional parameters not present in the request from having their keys added to `request.orig`, I added an explicit check for `undefined` in the `routeExt` function before adding the key to the request, preserving the original request.

This also fixes issues found integrating hapi-openapi and hapi-pagination.