### PR TITLE
Move from @hapi/join to joi to avoid error on mixing different version of joi schemas

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Package = require('../package.json');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const Hoek = require('@hapi/hoek');
 const Caller = require('./caller');
 const Path = require('path');

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Enjoi = require('enjoi');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const extensions = [
     { type: 'int64', base: Joi.string().regex(/^\d+$/) },

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
-    "@hapi/joi": "^17.1.0",
     "dot-prop": "^5.2.0",
     "enjoi": "git://github.com/sprootshift/enjoi",
+    "joi": "^17.1.0",
     "js-yaml": "^3.11.0",
     "merge-object-files": "^2.0.0",
     "swagger-parser": "^9.0.1"
@@ -27,7 +27,7 @@
     "@hapi/boom": "^9.1.0",
     "@hapi/eslint-config-hapi": "^13.0.2",
     "@hapi/eslint-plugin-hapi": "^4.3.5",
-    "@hapi/hapi": "^19.1.1",
+    "@hapi/hapi": "^20.0.3",
     "eslint": "^6.8.0",
     "nyc": "^15.0.0",
     "tape": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
     "dot-prop": "^5.2.0",
-    "enjoi": "git://github.com/sprootshift/enjoi",
+    "enjoi": "^9.0.0",
     "joi": "^17.1.0",
     "js-yaml": "^3.11.0",
     "merge-object-files": "^2.0.0",


### PR DESCRIPTION
Hello.

I've been trying to use this module, but it doesn't seem to work due to hapi and this module using different joi packages (this repo used @hapi/joi, hapi now uses joi)

Also updated enjoi to a version that also uses joi instead of @hapi/joi